### PR TITLE
rename paymentType() method to paymentMethod()

### DIFF
--- a/src/Concerns/Transactions/HasPaymentType.php
+++ b/src/Concerns/Transactions/HasPaymentType.php
@@ -428,8 +428,21 @@ trait HasPaymentType
      *
      * @param  PaymentType|null  $payment_type
      * @return $this
+     *
+     * @deprecated Use paymentMethod() instead.
      */
     public function paymentType(PaymentType | null $payment_type): static
+    {
+        return $this->paymentMethod($payment_type);
+    }
+
+    /**
+     * Assign payment method.
+     *
+     * @param  PaymentType|null  $payment_type
+     * @return $this
+     */
+    public function paymentMethod(PaymentType | null $payment_type): static
     {
         if ($payment_type) {
             $this->payment_type = $payment_type->getType();


### PR DESCRIPTION
- submodule wiki in 'docs' directory
- rename paymentType() method to paymentMethod(), use deprecation strategy
