### PR TITLE
properly getting orderId in status() method

### DIFF
--- a/src/Kasir.php
+++ b/src/Kasir.php
@@ -172,7 +172,7 @@ class Kasir implements Arrayable
      */
     public function status(): MidtransResponse
     {
-        $transaction_id = $this->transaction_details['order_id'];
+        $transaction_id = $this->getOrderId();
 
         return static::getStatus($transaction_id);
     }


### PR DESCRIPTION
The `status()` method from Kasir class is now properly getting the `order_id` from the object.