### PR TITLE
move Midtrans endpoint to Endpoint trait

### DIFF
--- a/src/Concerns/Endpoint.php
+++ b/src/Concerns/Endpoint.php
@@ -4,6 +4,13 @@ namespace Kasir\Kasir\Concerns;
 
 trait Endpoint
 {
+    protected static string $SANDBOX_BASE_URL = 'https://api.sandbox.midtrans.com';
+
+    protected static string $PRODUCTION_BASE_URL = 'https://api.midtrans.com';
+
+    protected static string $SNAP_SANDBOX_BASE_URL = 'https://app.sandbox.midtrans.com/snap/v1';
+
+    protected static string $SNAP_PRODUCTION_BASE_URL = 'https://app.midtrans.com/snap/v1';
     /**
      * Get Base URL for the API
      *
@@ -12,8 +19,8 @@ trait Endpoint
     public static function getBaseUrl(): string
     {
         return config('kasir.production_mode') === true
-            ? self::PRODUCTION_BASE_URL
-            : self::SANDBOX_BASE_URL;
+            ? static::$PRODUCTION_BASE_URL
+            : static::$SANDBOX_BASE_URL;
     }
 
     /**
@@ -24,7 +31,7 @@ trait Endpoint
     public static function getSnapBaseUrl(): string
     {
         return config('kasir.production_mode') === true
-            ? self::SNAP_PRODUCTION_BASE_URL
-            : self::SNAP_SANDBOX_BASE_URL;
+            ? static::$SNAP_PRODUCTION_BASE_URL
+            : static::$SNAP_SANDBOX_BASE_URL;
     }
 }

--- a/src/Concerns/Endpoint.php
+++ b/src/Concerns/Endpoint.php
@@ -11,6 +11,7 @@ trait Endpoint
     protected static string $SNAP_SANDBOX_BASE_URL = 'https://app.sandbox.midtrans.com/snap/v1';
 
     protected static string $SNAP_PRODUCTION_BASE_URL = 'https://app.midtrans.com/snap/v1';
+
     /**
      * Get Base URL for the API
      *

--- a/src/Kasir.php
+++ b/src/Kasir.php
@@ -42,14 +42,6 @@ class Kasir implements Arrayable
     use HasShippingAddress;
     use Validation;
 
-    const SANDBOX_BASE_URL = 'https://api.sandbox.midtrans.com';
-
-    const PRODUCTION_BASE_URL = 'https://api.midtrans.com';
-
-    const SNAP_SANDBOX_BASE_URL = 'https://app.sandbox.midtrans.com/snap/v1';
-
-    const SNAP_PRODUCTION_BASE_URL = 'https://app.midtrans.com/snap/v1';
-
     public function __construct(int | null $gross_amount)
     {
         $this->grossAmount($gross_amount);


### PR DESCRIPTION
Midtrans Base URLs is moved to the Endpoint trait, and now is `private static` type instead of `const`.