### PR TITLE
GitHub Release Notes Generator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: 🛠️ Breaking Changes
+      labels:
+        - breaking
+    - title: 🚀 Features
+      labels:
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📝 Documentation
+      labels:
+        - docs
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: 🔒 Security
+      labels:
+        - security


### PR DESCRIPTION
This PR creates `release.yml` file in `.github` directory to enable automatic release notes generator.

GitHub documentation: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes