### PR TITLE
Closure Support as `grossAmount()` Parameter

### DIFF
--- a/src/Concerns/Transactions/HasGrossAmount.php
+++ b/src/Concerns/Transactions/HasGrossAmount.php
@@ -4,9 +4,9 @@ namespace Kasir\Kasir\Concerns\Transactions;
 
 trait HasGrossAmount
 {
-    protected int | null $gross_amount;
+    protected int | \Closure | null $gross_amount;
 
-    public function grossAmount(int | null $gross_amount): static
+    public function grossAmount(int | \Closure | null $gross_amount): static
     {
         $this->gross_amount = $gross_amount;
         $this->gross_amount = $this->calculateGrossAmount();


### PR DESCRIPTION
`grossAmount()` method now supports `Closure` as the parameter.